### PR TITLE
Put node on least depth to show triangle connections better

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "em-tgraph",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Under development",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
@sreenaths, this patch does two things
- Fixes a common case where A has two outputs B and C, and B has one output C. Graph looks as below.

```
A
|
B
|
C
```
After the change, graphs shows the connections correctly instead of hiding the A -> C connection
```
A -> B
 \   |
  \  |
    C
```
- Fixes a problem where outputs weren't put underneath their vertex. Attaching before and after pictures

<img width="147" alt="screen shot 2017-10-24 at 12 10 53 am" src="https://user-images.githubusercontent.com/8976028/31925960-7853a960-b851-11e7-9741-6510bd0fc888.png">
<img width="310" alt="screen shot 2017-10-23 at 11 55 57 pm" src="https://user-images.githubusercontent.com/8976028/31925963-788adcf0-b851-11e7-9e3d-e7e26ecae033.png">
<img width="1354" alt="screen shot 2017-10-24 at 12 11 04 am" src="https://user-images.githubusercontent.com/8976028/31925959-784433d6-b851-11e7-90a2-503df1b8661b.png">
<img width="1340" alt="screen shot 2017-10-23 at 11 56 12 pm" src="https://user-images.githubusercontent.com/8976028/31925962-78785bac-b851-11e7-88fd-f0f213f2fb15.png">
<img width="1348" alt="screen shot 2017-10-24 at 12 11 15 am" src="https://user-images.githubusercontent.com/8976028/31925958-78333b1c-b851-11e7-95f7-cb9a1ba5592c.png">
<img width="796" alt="screen shot 2017-10-23 at 11 56 25 pm" src="https://user-images.githubusercontent.com/8976028/31925961-78648f5a-b851-11e7-83c9-941efab709ce.png">




