### PR TITLE
Missed a promotion case where inputs were dropped from the graph

### DIFF
--- a/addon/utils/data-processor.js
+++ b/addon/utils/data-processor.js
@@ -458,7 +458,7 @@ function _treefyData(vertex, depth) {
           }
         }
         else {
-          return;
+          return child;
         }
       }
       child.setParent(vertex);


### PR DESCRIPTION
@sreenaths, there is a case where a child is encounter twice and we don't want to drop the children if the child is not promoted